### PR TITLE
Remove unused functions fromo Sui Move module

### DIFF
--- a/move/testnet/switchboard_std/sources/math.move
+++ b/move/testnet/switchboard_std/sources/math.move
@@ -45,23 +45,6 @@ module switchboard_std::math {
         (value, dec, neg)
     }
 
-    fun max(a: u8, b: u8): u8 {
-        if (a > b) a else b
-    }
-
-    fun min(a: u8, b: u8): u8 {
-        if (a > b) b else a
-    }
-
-    // abs(a - b)
-    fun sub_abs_u8(a: u8, b: u8): u8 {
-        if (a > b) {
-            a - b
-        } else {
-            b - a
-        }
-    }
-
     public fun zero(): SwitchboardDecimal {
       SwitchboardDecimal {
         value: 0,
@@ -89,10 +72,6 @@ module switchboard_std::math {
 
     fun abs_gt(val1: &SwitchboardDecimal, val2: &SwitchboardDecimal): bool {
         val1.value > val2.value
-    }
-
-    fun abs_lt(val1: &SwitchboardDecimal, val2: &SwitchboardDecimal): bool {
-        val1.value < val2.value
     }
 
     public fun add(val1: &SwitchboardDecimal, val2: &SwitchboardDecimal): SwitchboardDecimal {


### PR DESCRIPTION
This PR removes unused functions from the testnet version of `switchboard_std`.
Their visibility was private, and they were not used anywhere in the module where they were defined.

# Problem

The removed functions prevent projects using `switchboard_std` as a dependency from being built with `sui move build`.
The issue I ran into was with the following `(sui, sui move)` versions:

```bash
$ sui --version
sui 1.5.0-c9b896c0b

$ sui move --version
sui-move 0.1.0
```